### PR TITLE
Fix broken location options :facepalm:

### DIFF
--- a/packages/basic/manifest.json
+++ b/packages/basic/manifest.json
@@ -9,8 +9,10 @@
   "private": true,
   "location": {
     "support": {
-      "ticket_sidebar": "assets/iframe.html",
-      "flexible": true
+      "ticket_sidebar": {
+        "url": "assets/iframe.html",
+        "flexible": true
+      }
     }
   },
   "version": "1.0.0",


### PR DESCRIPTION
@zendesk/vegemite

## Description
Fixes an analogous issue to that which was addressed by https://github.com/zendesk/apps_scaffold_basic/pull/2, wherein the location options for the basic scaffold were broken.

## Risks
* Low. Basic scaffold is still broken.
