### PR TITLE
Comply zaf_sdk.min.js with requirements

### DIFF
--- a/packages/react/webpack.config.js
+++ b/packages/react/webpack.config.js
@@ -7,7 +7,7 @@ const TranslationsPlugin = require('./webpack/translations-plugin')
 
 const externalAssets = {
   js: [
-    'https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js'
+    'https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.min.js'
   ]
 }
 
@@ -77,7 +77,15 @@ module.exports = {
       warning: 'AUTOMATICALLY GENERATED FROM ./src/templates/iframe.html - DO NOT MODIFY THIS FILE DIRECTLY',
       vendorJs: externalAssets.js,
       template: './src/templates/iframe.html',
-      filename: 'iframe.html'
+      filename: 'iframe.html',
+      minify: {
+        collapseWhitespace: true,
+        keepClosingSlash: true,
+        removeComments: true,
+        removeRedundantAttributes: false,
+        removeScriptTypeAttributes: false,
+        removeStyleLinkTypeAttributes: false,
+      }
     })
   ]
 }


### PR DESCRIPTION
Updates webpack so that the zaf_sdk.js link complies with zendesk requirements

@zendesk/vegemite

## Description
In submitting an app request to Zendesk, they requested that I change my zaf_sdk link to be minified, and to include the script type.
This updates the scaffolding to comply with this by default.

## Risks
* [low] Does it work across browsers (including IE!)?
* [low] Does it work in the different products (Support, Chat, Connect)?
* [low] Are there any performance implications?
* [low] Any security risks?
* [low] What features does this touch?
