### PR TITLE
[VEG-2332] Remove serving garden components via 3rd party CDN

### DIFF
--- a/packages/basic/assets/iframe.html
+++ b/packages/basic/assets/iframe.html
@@ -7,7 +7,6 @@
     https://garden.zendesk.com/css-components/bedrock/
     https://garden.zendesk.com/css-components/utilities/typography/
    -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/combine/npm/@zendeskgarden/css-bedrock@7.0.21,npm/@zendeskgarden/css-utilities@4.3.0">
 </head>
 <body>
   <h2 class="u-semibold u-fs-xl">Hello, World!</h2>


### PR DESCRIPTION
@zendesk/vegemite

## Description
We don’t want to encourage developers to use a CDN we don’t control. Including a link to it in our official scaffolding app indicates we do. We want to remove this reference and replace it with an alternative.

## Tasks
- [ ] Write tests

## References
[Jira](https://zendesk.atlassian.net/browse/VEG-2332)

## Screenshots (if needed)
<details>
<summary>Screenshot 1</summary>
<img src="1.png">
</details>

<details>
<summary>Screenshot 2</summary>
<img src="2.png">
</details>

## Risks
* LOW: Merely removing a css stylesheet link 
