### PR TITLE
Updates for windows

### DIFF
--- a/packages/react/rollup/static-copy-plugin.js
+++ b/packages/react/rollup/static-copy-plugin.js
@@ -13,6 +13,8 @@ export default function StaticCopy({ targets }) {
       const rootPath = config.build.outDir
       await Promise.all(
         targets.map(async ({ src, dest, modifier = (data) => data }) => {
+          // This is to compensate for windows file paths and how glob works
+          src = src.replaceAll("\\", "/")
           const paths = await glob(src)
           const destinationPath = path.resolve(rootPath, dest)
           await processFiles(paths, destinationPath, modifier)

--- a/packages/react/rollup/translations-loader-plugin.js
+++ b/packages/react/rollup/translations-loader-plugin.js
@@ -27,7 +27,8 @@ export default function TranslationsLoader() {
   return {
     name: 'translations-loader',
     transform: async (_, id) => {
-      if (id.endsWith('.json') && id.includes(path.resolve(__dirname, '../src/translations'))) {
+      // The replaceAll is to compensate for windows file paths having backslashes instead of forward slashes
+      if (id.endsWith('.json') && id.includes(path.resolve(__dirname, '../src/translations').replaceAll("\\", "/"))) {
         const contentFile = await fs.readFile(id)
 
         const translations = JSON.parse(contentFile)


### PR DESCRIPTION
@zendesk/vegemite

## Description
The two files in the rollup folder do not work properly when trying to build the package on a Windows machine.
Since Window's uses backslashes for it's directory separator it becomes and issue when the build function tries to copy the manifest file and the files from the assets.

Updating these two files to replace the backslashes with forward slashes resolved the issue and allowed npm to properly build the files.

I both replicated the initial issue where npm build was NOT able to copy over the assets and manifest, then applied these two changes and confirmed it was able to build the package successfully.

Please let me know if you have any questions
Thanks!
Todd